### PR TITLE
Fix in Kaf Ouput

### DIFF
--- a/src/main/java/es/ehu/si/ixa/ixa/pipe/tok/Annotate.java
+++ b/src/main/java/es/ehu/si/ixa/ixa/pipe/tok/Annotate.java
@@ -103,9 +103,9 @@ public class Annotate {
             ++noSents;
           }
         } else {
-          WF wf = kaf.newWF(token.value(), token.startOffset());
+          WF wf = kaf.newWF(token.value(), token.startOffset(),noSents);
           wf.setPara(noParas);
-          wf.setSent(noSents);
+          //wf.setSent(noSents);          
         }
       }
     }


### PR DESCRIPTION
Fixed bug in KafOutput. 

The error seems to be related that at creation time, the wf sentece is indexed. Then altering it after creation has no effect (the indexBySent should be modified)

/*\* Adds a word form to the container */
    void add(WF wf) {
    text.add(wf);
    //nextOffset += wf.getLength() + 1;
    this.indexBySent(wf, wf.getSent(), this.textIndexedBySent);
    }

Gracias de todas formas por ofrecer tu ayuda ;)
