### PR TITLE
Add property to provide custom resources directory

### DIFF
--- a/src/main/java/eus/ixa/ixa/pipe/tok/NonPeriodBreaker.java
+++ b/src/main/java/eus/ixa/ixa/pipe/tok/NonPeriodBreaker.java
@@ -17,6 +17,9 @@
 package eus.ixa.ixa.pipe.tok;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -96,19 +99,24 @@ public class NonPeriodBreaker {
   }
 
   private void loadNonBreaker(final Properties properties) {
-    final String lang = properties.getProperty("language");
     if (NON_BREAKER == null) {
-      createNonBreaker(lang);
+      final String lang = properties.getProperty("language");
+      final String resourcesDirectory = properties.getProperty("resourcesDirectory");
+      createNonBreaker(lang, resourcesDirectory);
     }
   }
 
-  private void createNonBreaker(final String lang) {
+  private void createNonBreaker(final String lang, final String resourcesDirectory) {
     final List<String> nonBreakerList = new ArrayList<String>();
 
-    final InputStream nonBreakerInputStream = getNonBreakerInputStream(lang);
+    final InputStream nonBreakerInputStream = resourcesDirectory == null
+      ? getNonBreakerInputStream(lang)
+      : getNonBreakerInputStreamFromDirectory(lang, resourcesDirectory);
+
     if (nonBreakerInputStream == null) {
+      final String resourcesLocation = resourcesDirectory == null ? "src/main/resources" : resourcesDirectory;
       System.err.println("ERROR: Not nonbreaker file for language " + lang
-          + " in src/main/resources!!");
+          + " in " + resourcesLocation + "!!");
       System.exit(1);
     }
     final BufferedReader breader = new BufferedReader(new InputStreamReader(
@@ -125,6 +133,14 @@ public class NonPeriodBreaker {
       e.printStackTrace();
     }
     NON_BREAKER = StringUtils.createDisjunctRegexFromList(nonBreakerList);
+  }
+
+  private final InputStream getNonBreakerInputStreamFromDirectory(final String lang, final String resourcesDirectory) {
+    try {
+      return new FileInputStream(new File(resourcesDirectory, lang.toLowerCase() + "-nonbreaker.txt"));
+    } catch (FileNotFoundException ex) {
+      return null;
+    }
   }
 
   private final InputStream getNonBreakerInputStream(final String lang) {


### PR DESCRIPTION
Currently there is only one way to provide the linguistic resources (e.g. non-breaker files) to the tokenizer: packaging the files with the tokenizer jar.

I currently work on the Fortis project [1], a social data analysis platform for the United Nations. For this project, we'd like the ability to update the linguistic resources without re-deploying a new jar file. As such, we need a way to provide the linguistic resources to the tokenizer without changing the jar. This pull request implements such a mechanism by adding a new property called `resourcesDirectory`. If this property is set to an existing directory, the tokenizer will try to load the linguistic resources from this directory instead of from the jar file.

Another nice property of this change is that it'll make it easier for users to comply with the terms of the license of the linguistic resources, the LGPL-LR [2], as we no longer need to bundle the LGPL-LR resources together with the tokenizer code which means that the application will count as a "work that uses the Linguistic Resource" and as such fall outside the scope of the license.

[1] https://fortis-web.azurewebsites.net/#/site/ocha/
[2] http://infolingu.univ-mlv.fr/DonneesLinguistiques/Lexiques-Grammaires/lgpllr.html